### PR TITLE
Add discontinuity field in TS and PES packets

### DIFF
--- a/lib/mpeg/ts/demuxer.ex
+++ b/lib/mpeg/ts/demuxer.ex
@@ -27,7 +27,7 @@ defmodule MPEG.TS.Demuxer do
   @spec new() :: t()
   def new(), do: %__MODULE__{packet_filter: fn _ -> true end}
 
-  def push_buffer(state, buffer, discontinuity) do
+  def push_buffer(state, buffer, discontinuity \\ false) do
     {ok, bytes_to_buffer} = parse_buffer(state.buffered_bytes <> buffer)
 
     ok =
@@ -111,7 +111,7 @@ defmodule MPEG.TS.Demuxer do
       discard_count = length(packets)
 
       if discard_count > 0 do
-        Logger.warn(
+        Logger.warning(
           "Discarding #{discard_count} packets while waiting for random access indicator",
           domain: __MODULE__
         )

--- a/lib/mpeg/ts/demuxer.ex
+++ b/lib/mpeg/ts/demuxer.ex
@@ -27,9 +27,10 @@ defmodule MPEG.TS.Demuxer do
   @spec new() :: t()
   def new(), do: %__MODULE__{packet_filter: fn _ -> true end}
 
-  def push_buffer(state, buffer) do
+  def push_buffer(state, buffer, from, chunk_id) do
     {ok, bytes_to_buffer} = parse_buffer(state.buffered_bytes <> buffer)
-
+    ok = Enum.map(ok, fn ts -> %{ts | from: from, chunk_id: chunk_id} end)
+    if bytes_to_buffer != <<>>, do: Logger.warning("Not all buffers have been processed")
     state = push_packets(%__MODULE__{state | buffered_bytes: <<>>}, ok)
     %__MODULE__{state | buffered_bytes: bytes_to_buffer}
   end

--- a/lib/mpeg/ts/demuxer.ex
+++ b/lib/mpeg/ts/demuxer.ex
@@ -27,9 +27,14 @@ defmodule MPEG.TS.Demuxer do
   @spec new() :: t()
   def new(), do: %__MODULE__{packet_filter: fn _ -> true end}
 
-  def push_buffer(state, buffer, from, chunk_id) do
+  def push_buffer(state, buffer, discontinuity) do
     {ok, bytes_to_buffer} = parse_buffer(state.buffered_bytes <> buffer)
-    ok = Enum.map(ok, fn ts -> %{ts | from: from, chunk_id: chunk_id} end)
+
+    ok =
+      Enum.map(ok, fn ts ->
+        %{ts | discontinuity: discontinuity}
+      end)
+
     if bytes_to_buffer != <<>>, do: Logger.warning("Not all buffers have been processed")
     state = push_packets(%__MODULE__{state | buffered_bytes: <<>>}, ok)
     %__MODULE__{state | buffered_bytes: bytes_to_buffer}

--- a/lib/mpeg/ts/packet.ex
+++ b/lib/mpeg/ts/packet.ex
@@ -22,7 +22,9 @@ defmodule MPEG.TS.Packet do
           scrambling: scrambling_t(),
           discontinuity_indicator: boolean(),
           random_access_indicator: boolean(),
-          pcr: pos_integer()
+          pcr: pos_integer(),
+          from: non_neg_integer() | nil,
+          chunk_id: non_neg_integer()
         }
   @derive {Inspect,
            only: [
@@ -31,7 +33,9 @@ defmodule MPEG.TS.Packet do
              :continuity_counter,
              :discontinuity_indicator,
              :random_access_indicator,
-             :payload
+             :payload,
+             :from,
+             :chunk_id
            ]}
   defstruct [
     :payload,
@@ -41,7 +45,9 @@ defmodule MPEG.TS.Packet do
     :scrambling,
     :discontinuity_indicator,
     :random_access_indicator,
-    :pcr
+    :pcr,
+    :from,
+    :chunk_id
   ]
 
   @type parse_error_t ::

--- a/lib/mpeg/ts/packet.ex
+++ b/lib/mpeg/ts/packet.ex
@@ -44,7 +44,7 @@ defmodule MPEG.TS.Packet do
     :discontinuity_indicator,
     :random_access_indicator,
     :pcr,
-    :discontinuity
+    discontinuity: false
   ]
 
   @type parse_error_t ::

--- a/lib/mpeg/ts/packet.ex
+++ b/lib/mpeg/ts/packet.ex
@@ -23,8 +23,7 @@ defmodule MPEG.TS.Packet do
           discontinuity_indicator: boolean(),
           random_access_indicator: boolean(),
           pcr: pos_integer(),
-          from: non_neg_integer() | nil,
-          chunk_id: non_neg_integer()
+          discontinuity: boolean()
         }
   @derive {Inspect,
            only: [
@@ -34,8 +33,7 @@ defmodule MPEG.TS.Packet do
              :discontinuity_indicator,
              :random_access_indicator,
              :payload,
-             :from,
-             :chunk_id
+             :discontinuity
            ]}
   defstruct [
     :payload,
@@ -46,8 +44,7 @@ defmodule MPEG.TS.Packet do
     :discontinuity_indicator,
     :random_access_indicator,
     :pcr,
-    :from,
-    :chunk_id
+    :discontinuity
   ]
 
   @type parse_error_t ::

--- a/lib/mpeg/ts/partial_pes.ex
+++ b/lib/mpeg/ts/partial_pes.ex
@@ -14,10 +14,9 @@ defmodule MPEG.TS.PartialPES do
           pts: pos_integer(),
           dts: pos_integer(),
           is_aligned: boolean(),
-          from: non_neg_integer(),
-          chunk_id: non_neg_integer()
+          discontinuity: boolean()
         }
-  defstruct [:data, :stream_id, :pts, :dts, :is_aligned, :from, :chunk_id]
+  defstruct [:data, :stream_id, :pts, :dts, :is_aligned, :discontinuity]
 
   require Logger
 

--- a/lib/mpeg/ts/partial_pes.ex
+++ b/lib/mpeg/ts/partial_pes.ex
@@ -13,9 +13,11 @@ defmodule MPEG.TS.PartialPES do
           stream_id: pos_integer(),
           pts: pos_integer(),
           dts: pos_integer(),
-          is_aligned: boolean()
+          is_aligned: boolean(),
+          from: non_neg_integer(),
+          chunk_id: non_neg_integer()
         }
-  defstruct [:data, :stream_id, :pts, :dts, :is_aligned]
+  defstruct [:data, :stream_id, :pts, :dts, :is_aligned, :from, :chunk_id]
 
   require Logger
 
@@ -33,7 +35,10 @@ defmodule MPEG.TS.PartialPES do
   end
 
   @impl true
-  def unmarshal(<<1::24, stream_id::8, _packet_length::16, optional_fields::bitstring>>, true) do
+  def unmarshal(
+        <<1::24, stream_id::8, _packet_length::16, optional_fields::bitstring>>,
+        true
+      ) do
     # Packet length is ignored as the field is also allowed to be zero in case
     # the payload is a video elementary stream. If the PES packet length is set
     # to zero, the PES packet can be of any length.

--- a/lib/mpeg/ts/partial_pes.ex
+++ b/lib/mpeg/ts/partial_pes.ex
@@ -158,7 +158,7 @@ defmodule MPEG.TS.PartialPES do
 
     if pts - dts > 60 * @ts_clock_hz do
       # https://github.com/video-dev/hls.js/blob/c14628668e04d14f0217d0118f7e768933524c6d/src/demux/tsdemuxer.ts#L1106
-      Logger.warn(
+      Logger.warning(
         "#{round((pts - dts) / @ts_clock_hz)} delta between PTS and DTS. Aligning them using DTS."
       )
 

--- a/lib/mpeg/ts/pes.ex
+++ b/lib/mpeg/ts/pes.ex
@@ -1,4 +1,4 @@
 defmodule MPEG.TS.PES do
-  @derive {Inspect, only: [:stream_id, :pts, :dts, :is_aligned]}
-  defstruct [:data, :stream_id, :pts, :dts, :is_aligned]
+  @derive {Inspect, only: [:stream_id, :pts, :dts, :is_aligned, :from, :chunk_id]}
+  defstruct [:data, :stream_id, :pts, :dts, :is_aligned, :from, :chunk_id]
 end

--- a/lib/mpeg/ts/pes.ex
+++ b/lib/mpeg/ts/pes.ex
@@ -1,4 +1,4 @@
 defmodule MPEG.TS.PES do
-  @derive {Inspect, only: [:stream_id, :pts, :dts, :is_aligned, :from, :chunk_id]}
-  defstruct [:data, :stream_id, :pts, :dts, :is_aligned, :from, :chunk_id]
+  @derive {Inspect, only: [:stream_id, :pts, :dts, :is_aligned, :discontinuity]}
+  defstruct [:data, :stream_id, :pts, :dts, :is_aligned, :discontinuity]
 end

--- a/lib/mpeg/ts/pes.ex
+++ b/lib/mpeg/ts/pes.ex
@@ -1,4 +1,4 @@
 defmodule MPEG.TS.PES do
   @derive {Inspect, only: [:stream_id, :pts, :dts, :is_aligned, :discontinuity]}
-  defstruct [:data, :stream_id, :pts, :dts, :is_aligned, :discontinuity]
+  defstruct [:data, :stream_id, :pts, :dts, :is_aligned, discontinuity: false]
 end

--- a/lib/mpeg/ts/stream_queue.ex
+++ b/lib/mpeg/ts/stream_queue.ex
@@ -105,8 +105,7 @@ defmodule MPEG.TS.StreamQueue do
         dts: leader.dts,
         # the information about alignment should be available in the first `PartialPES`
         is_aligned: leader.is_aligned,
-        from: leader.from,
-        chunk_id: leader.chunk_id
+        discontinuity: leader.discontinuity
       }
     else
       nil
@@ -116,7 +115,7 @@ defmodule MPEG.TS.StreamQueue do
   defp unmarshal_partial_pes!(packet) do
     case PartialPES.unmarshal(packet.payload, packet.pusi) do
       {:ok, pes} ->
-        %{pes | from: packet.from, chunk_id: packet.chunk_id}
+        %{pes | discontinuity: packet.discontinuity}
 
       {:error, reason} ->
         raise ArgumentError,

--- a/lib/mpeg/ts/stream_queue.ex
+++ b/lib/mpeg/ts/stream_queue.ex
@@ -104,7 +104,9 @@ defmodule MPEG.TS.StreamQueue do
         pts: leader.pts,
         dts: leader.dts,
         # the information about alignment should be available in the first `PartialPES`
-        is_aligned: leader.is_aligned
+        is_aligned: leader.is_aligned,
+        from: leader.from,
+        chunk_id: leader.chunk_id
       }
     else
       nil
@@ -114,7 +116,7 @@ defmodule MPEG.TS.StreamQueue do
   defp unmarshal_partial_pes!(packet) do
     case PartialPES.unmarshal(packet.payload, packet.pusi) do
       {:ok, pes} ->
-        pes
+        %{pes | from: packet.from, chunk_id: packet.chunk_id}
 
       {:error, reason} ->
         raise ArgumentError,


### PR DESCRIPTION
This PR:
* adds `discontinuity` field to the MPEG.TS.PES packets created from a given input buffer, based on the value passed to the `push_buffer` function along that buffer