### PR TITLE
Add marshaler

### DIFF
--- a/lib/mpeg/ts/marshaler.ex
+++ b/lib/mpeg/ts/marshaler.ex
@@ -15,12 +15,3 @@ end
 defimpl MPEG.TS.Marshaler, for: List do
   def marshal(list), do: Enum.map(list, &MPEG.TS.Marshaler.marshal/1)
 end
-
-defimpl MPEG.TS.Marshaler, for: Map do
-  # we consider this map, the PAT
-  def marshal(pat) do
-    Enum.map_join(pat, fn {program_number, pid} ->
-      <<program_number::16, 0b111::3, pid::13>>
-    end)
-  end
-end

--- a/lib/mpeg/ts/marshaler.ex
+++ b/lib/mpeg/ts/marshaler.ex
@@ -1,0 +1,26 @@
+defprotocol MPEG.TS.Marshaler do
+  @moduledoc """
+  A protocol defining the behavior for marshaling MPEG-TS packets.
+  """
+
+  @fallback_to_any true
+
+  @doc """
+  Marshal a packet.
+  """
+  @spec marshal(t()) :: iodata()
+  def marshal(packet)
+end
+
+defimpl MPEG.TS.Marshaler, for: List do
+  def marshal(list), do: Enum.map(list, &MPEG.TS.Marshaler.marshal/1)
+end
+
+defimpl MPEG.TS.Marshaler, for: Map do
+  # we consider this map, the PAT
+  def marshal(pat) do
+    Enum.map_join(pat, fn {program_number, pid} ->
+      <<program_number::16, 0b111::3, pid::13>>
+    end)
+  end
+end

--- a/lib/mpeg/ts/packet.ex
+++ b/lib/mpeg/ts/packet.ex
@@ -55,7 +55,7 @@ defmodule MPEG.TS.Packet do
 
   @spec new(payload :: payload_t(), opts :: keyword()) :: t()
   def new(payload, opts \\ []) do
-    struct!(%__MODULE__{payload: payload}, opts)
+    struct(%__MODULE__{payload: payload}, opts)
   end
 
   @spec parse(binary()) ::

--- a/lib/mpeg/ts/packet.ex
+++ b/lib/mpeg/ts/packet.ex
@@ -39,11 +39,11 @@ defmodule MPEG.TS.Packet do
            ]}
   defstruct [
     :payload,
-    :pusi,
     :pid,
     :pid_class,
     :continuity_counter,
     :pcr,
+    pusi: false,
     scrambling: :no,
     discontinuity_indicator: false,
     random_access_indicator: false,
@@ -52,6 +52,11 @@ defmodule MPEG.TS.Packet do
 
   @type parse_error_t ::
           :invalid_data | :invalid_packet | :unsupported_packet
+
+  @spec new(payload :: payload_t(), opts :: keyword()) :: t()
+  def new(payload, opts \\ []) do
+    struct!(%__MODULE__{payload: payload}, opts)
+  end
 
   @spec parse(binary()) ::
           {:ok, t} | {:error, parse_error_t, binary()}

--- a/lib/mpeg/ts/partial_pes.ex
+++ b/lib/mpeg/ts/partial_pes.ex
@@ -60,11 +60,12 @@ defmodule MPEG.TS.PartialPES do
   @private_1_stream_id 0xBD
   @private_2_stream_id 0xBF
 
-  defp has_header?(id)
-       when id in [@padding_stream_id, @private_1_stream_id, @private_2_stream_id],
-       do: false
+  @spec has_header?(pos_integer()) :: boolean()
+  def has_header?(id)
+      when id in [@padding_stream_id, @private_1_stream_id, @private_2_stream_id],
+      do: false
 
-  defp has_header?(_other), do: true
+  def has_header?(_other), do: true
 
   defp parse_optional_header(data, false), do: {:ok, %{}, 0, data}
 

--- a/lib/mpeg/ts/pes.ex
+++ b/lib/mpeg/ts/pes.ex
@@ -41,7 +41,7 @@ defmodule MPEG.TS.PES do
     end
 
     defp pts_dts_indicator(%{dts: nil, pts: nil}), do: 0
-    defp pts_dts_indicator(%{dts: nil}), do: 1
+    defp pts_dts_indicator(%{dts: nil}), do: 2
     defp pts_dts_indicator(_pes), do: 3
 
     defp marshal_pts_dts(%{dts: nil, pts: nil}), do: <<>>

--- a/lib/mpeg/ts/pes.ex
+++ b/lib/mpeg/ts/pes.ex
@@ -13,7 +13,7 @@ defmodule MPEG.TS.PES do
 
   @spec new(binary(), keyword()) :: t()
   def new(data, opts) do
-    struct!(%__MODULE__{data: data}, opts)
+    struct(%__MODULE__{data: data}, opts)
   end
 
   defimpl MPEG.TS.Marshaler do

--- a/lib/mpeg/ts/pes.ex
+++ b/lib/mpeg/ts/pes.ex
@@ -18,7 +18,7 @@ defmodule MPEG.TS.PES do
 
   defimpl MPEG.TS.Marshaler do
     alias MPEG.TS.PartialPES
-    @max_pes_size 0xFFFFF
+    @max_pes_size 0xFFFF
 
     def marshal(pes) do
       optional_header =

--- a/lib/mpeg/ts/pes.ex
+++ b/lib/mpeg/ts/pes.ex
@@ -1,4 +1,62 @@
 defmodule MPEG.TS.PES do
+  @type t :: %__MODULE__{
+          data: binary(),
+          stream_id: 0..255,
+          pts: non_neg_integer() | nil,
+          dts: non_neg_integer() | nil,
+          is_aligned: boolean(),
+          discontinuity: boolean()
+        }
+
   @derive {Inspect, only: [:stream_id, :pts, :dts, :is_aligned, :discontinuity]}
   defstruct [:data, :stream_id, :pts, :dts, :is_aligned, discontinuity: false]
+
+  @spec new(binary(), keyword()) :: t()
+  def new(data, opts) do
+    struct!(%__MODULE__{data: data}, opts)
+  end
+
+  defimpl MPEG.TS.Marshaler do
+    alias MPEG.TS.PartialPES
+    @max_pes_size 0xFFFFF
+
+    def marshal(pes) do
+      optional_header =
+        case PartialPES.has_header?(pes.stream_id) do
+          true ->
+            pts_dts = marshal_pts_dts(pes)
+
+            <<_marker_bits = 0b10::2, _scrambling_control = 0::2, _priority = 0::1,
+              _data_alignment = 1::1, _copyright = 0::1, _original = 0::1,
+              pts_dts_indicator(pes)::2, 0::6, byte_size(pts_dts)::8, pts_dts::binary>>
+
+          false ->
+            <<>>
+        end
+
+      size = byte_size(pes.data) + byte_size(optional_header)
+      size = if size > @max_pes_size, do: 0, else: size
+
+      <<1::24, pes.stream_id, size::16, optional_header::binary, pes.data::binary>>
+    end
+
+    defp pts_dts_indicator(%{dts: nil, pts: nil}), do: 0
+    defp pts_dts_indicator(%{dts: nil}), do: 1
+    defp pts_dts_indicator(_pes), do: 3
+
+    defp marshal_pts_dts(%{dts: nil, pts: nil}), do: <<>>
+    defp marshal_pts_dts(%{dts: nil, pts: pts}), do: marshal_timestamp(0b0010, pts)
+
+    defp marshal_pts_dts(%{dts: dts, pts: pts}) do
+      marshal_timestamp(0b0011, pts) <> marshal_timestamp(0b0001, dts)
+    end
+
+    defp marshal_timestamp(prefix, timestamp) do
+      chunk1 = Bitwise.bsr(timestamp, 30)
+      chunk2 = Bitwise.bsr(timestamp, 15) |> Bitwise.band(0x7FFF)
+      chunk3 = Bitwise.band(timestamp, 0x7FFF)
+
+      <<prefix::4, chunk1::3, 0b1::1, chunk2::15, 0b1::1, chunk3::15, 0b1::1>>
+    end
+  end
 end

--- a/test/mpeg/ts/packet_test.exs
+++ b/test/mpeg/ts/packet_test.exs
@@ -1,7 +1,7 @@
 defmodule MPEG.TS.PacketTest do
   use ExUnit.Case
 
-  alias MPEG.TS.Packet
+  alias MPEG.TS.{Marshaler, Packet}
   alias Support.Factory
 
   describe "MPEG TS Packet parser" do
@@ -32,6 +32,57 @@ defmodule MPEG.TS.PacketTest do
     test "fails when garbage is provided" do
       data = "garbagio"
       assert {:error, :invalid_data, ^data} = Packet.parse(data)
+    end
+  end
+
+  describe "MPEG TS Packet marshaler" do
+    test "Marshal a packet with only payload" do
+      payload = :binary.copy(<<0x01>>, 184)
+      expected_payload = <<0x47, 0x01, 0x00, 0x1F, payload::binary>>
+
+      packet = Packet.new(payload, pid: 0x100, continuity_counter: 15)
+      assert Marshaler.marshal(packet) == expected_payload
+
+      assert {:ok,
+              %Packet{
+                payload: ^payload,
+                continuity_counter: 15,
+                pid: 0x100,
+                pusi: false,
+                random_access_indicator: false,
+                scrambling: :no
+              }} = Packet.parse(expected_payload)
+    end
+
+    test "Marshal a packet with payload and adaptation" do
+      payload = :binary.copy(<<0x01>>, 176)
+
+      expected_payload =
+        <<0x47, 0x41, 0x00, 0x3A, 0x07, 0x50, 0x00, 0x00, 0x00, 0x01, 0xFE, 0x64,
+          payload::binary>>
+
+      packet =
+        Packet.new(payload,
+          pid: 0x100,
+          continuity_counter: 10,
+          random_access_indicator: true,
+          pusi: true,
+          pcr: 1000
+        )
+
+      assert Marshaler.marshal(packet) == expected_payload
+    end
+
+    test "Add stuffing bytes" do
+      payload = :binary.copy(<<0x01>>, 10)
+
+      expected_payload =
+        <<0x47, 0x41, 0x00, 0x3A, 0xAD, 0x00>> <> :binary.copy(<<0xFF>>, 172) <> payload
+
+      packet = Packet.new(payload, pid: 0x100, continuity_counter: 10, pusi: true)
+
+      assert Marshaler.marshal(packet) == expected_payload
+      assert {:ok, %Packet{payload: ^payload}} = Packet.parse(expected_payload)
     end
   end
 end

--- a/test/mpeg/ts/packet_test.exs
+++ b/test/mpeg/ts/packet_test.exs
@@ -41,7 +41,7 @@ defmodule MPEG.TS.PacketTest do
       expected_payload = <<0x47, 0x01, 0x00, 0x1F, payload::binary>>
 
       packet = Packet.new(payload, pid: 0x100, continuity_counter: 15)
-      assert Marshaler.marshal(packet) == expected_payload
+      assert Marshaler.marshal(packet) |> IO.iodata_to_binary() == expected_payload
 
       assert {:ok,
               %Packet{
@@ -70,7 +70,7 @@ defmodule MPEG.TS.PacketTest do
           pcr: 1000
         )
 
-      assert Marshaler.marshal(packet) == expected_payload
+      assert Marshaler.marshal(packet) |> IO.iodata_to_binary() == expected_payload
     end
 
     test "Add stuffing bytes" do
@@ -81,7 +81,7 @@ defmodule MPEG.TS.PacketTest do
 
       packet = Packet.new(payload, pid: 0x100, continuity_counter: 10, pusi: true)
 
-      assert Marshaler.marshal(packet) == expected_payload
+      assert Marshaler.marshal(packet) |> IO.iodata_to_binary() == expected_payload
       assert {:ok, %Packet{payload: ^payload}} = Packet.parse(expected_payload)
     end
   end

--- a/test/mpeg/ts/pat_test.exs
+++ b/test/mpeg/ts/pat_test.exs
@@ -13,4 +13,10 @@ defmodule MPEG.TS.PATTest do
       assert {:error, :invalid_data} = PAT.unmarshal_table(<<123, 32, 22, 121, 33>>)
     end
   end
+
+  describe "Marshal program association table" do
+    test "marshals a PAT" do
+      assert Marshaler.marshal(%{1 => 4096}) == Factory.pat()
+    end
+  end
 end

--- a/test/mpeg/ts/pat_test.exs
+++ b/test/mpeg/ts/pat_test.exs
@@ -6,7 +6,7 @@ defmodule MPEG.TS.PATTest do
 
   describe "Program association table parser" do
     test "parses valid packet" do
-      assert {:ok, %{1 => 4096}} = PAT.unmarshal_table(Factory.pat())
+      assert {:ok, %PAT{programs: %{1 => 4096}}} = PAT.unmarshal_table(Factory.pat())
     end
 
     test "returns an error when data is not valid" do
@@ -16,7 +16,7 @@ defmodule MPEG.TS.PATTest do
 
   describe "Marshal program association table" do
     test "marshals a PAT" do
-      assert Marshaler.marshal(%{1 => 4096}) == Factory.pat()
+      assert Marshaler.marshal(%PAT{programs: %{1 => 4096}}) == Factory.pat()
     end
   end
 end

--- a/test/mpeg/ts/pat_test.exs
+++ b/test/mpeg/ts/pat_test.exs
@@ -1,7 +1,7 @@
 defmodule MPEG.TS.PATTest do
   use ExUnit.Case
 
-  alias MPEG.TS.PAT
+  alias MPEG.TS.{Marshaler, PAT}
   alias Support.Factory
 
   describe "Program association table parser" do

--- a/test/mpeg/ts/pes_test.exs
+++ b/test/mpeg/ts/pes_test.exs
@@ -1,0 +1,33 @@
+defmodule MPEG.TS.PESTest do
+  use ExUnit.Case, async: true
+
+  alias MPEG.TS.{Marshaler, PartialPES, PES}
+
+  @payload <<0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF>>
+  @pes_payload <<0, 0, 1, 224, 0, 28, 132, 192, 10, 49, 0, 1, 14, 17, 17, 0, 1, 7, 9,
+                 @payload::binary>>
+
+  describe "marshal a PES packet" do
+    test "marshal a PES packet" do
+      pes = PES.new(@payload, stream_id: 224, dts: 900, pts: 1800)
+      assert Marshaler.marshal(pes) == @pes_payload
+
+      assert {:ok, %PartialPES{data: @payload, stream_id: 224, dts: 10_000_000, pts: 20_000_000}} =
+               PartialPES.unmarshal(@pes_payload, true)
+    end
+
+    test "marshal a PES with only pts" do
+      pes_payload = PES.new(@payload, stream_id: 224, pts: 1800) |> Marshaler.marshal()
+
+      assert {:ok, %PartialPES{data: @payload, stream_id: 224, dts: 20_000_000, pts: 20_000_000}} =
+               PartialPES.unmarshal(pes_payload, true)
+    end
+
+    test "marshal a PES without pts and dts" do
+      pes_payload = PES.new(@payload, stream_id: 224) |> Marshaler.marshal()
+
+      assert {:ok, %PartialPES{data: @payload, stream_id: 224, dts: nil, pts: nil}} =
+               PartialPES.unmarshal(pes_payload, true)
+    end
+  end
+end

--- a/test/mpeg/ts/pmt_test.exs
+++ b/test/mpeg/ts/pmt_test.exs
@@ -2,6 +2,7 @@ defmodule MPEG.TS.PMTTest do
   use ExUnit.Case
   doctest MPEG.TS.PMT, import: true
 
+  alias MPEG.TS.Marshaler
   alias MPEG.TS.PMT
   alias MPEG.TS.Packet
   alias Support.Factory
@@ -33,6 +34,21 @@ defmodule MPEG.TS.PMTTest do
     test "unmarshals valid packet" do
       {:ok, packet} = Packet.parse(Factory.pmt_packet())
       assert {:ok, %PMT{}} = PMT.unmarshal(packet.payload, packet.pusi)
+    end
+  end
+
+  describe "PMT marshaler" do
+    test "marshal a PMT" do
+      pmt = %PMT{
+        pcr_pid: 0x0100,
+        program_info: [],
+        streams: %{
+          256 => %{stream_type: :H264, stream_type_id: 0x1B},
+          257 => %{stream_type: :MPEG1_AUDIO, stream_type_id: 0x03}
+        }
+      }
+
+      assert Marshaler.marshal(pmt) == Factory.pmt()
     end
   end
 end


### PR DESCRIPTION
Add a marshaler to serialize mpeg-ts packets. I opted for a `protocol` definition  `MPEG.TS.Marshaler` which is implemented by the different packets modules. Should we make the `PAT` a struct too ??

