### PR TITLE
Add stream aggregator for streams with type :metadata 

### DIFF
--- a/lib/mpeg/ts/demuxer.ex
+++ b/lib/mpeg/ts/demuxer.ex
@@ -179,7 +179,7 @@ defmodule MPEG.TS.Demuxer do
   end
 
   defp demux_packets(state, [pkt | pkts], acc)
-       when pkt.pid_class in [:psi, :pat] or is_map_key(state.pids_with_pmt, pkt.pid) do
+       when pkt.pid_class in [:pat, :psi] or is_map_key(state.pids_with_pmt, pkt.pid) do
     with {:ok, psi} <- PSI.unmarshal(pkt.payload, pkt.pusi) do
       state =
         cond do
@@ -221,7 +221,7 @@ defmodule MPEG.TS.Demuxer do
 
   defp demux_packets(state, [pkt | pkts], acc) do
     # This packet does not belong to any PES stream we know -- it might be
-    # an unknown stream (we did not receive PMTs yet) or a PSI stream. 
+    # an unknown stream (we did not receive PMTs yet) or a PSI stream.
     Logger.warning("Unexpected packet received: #{inspect(pkt)}")
     demux_packets(state, pkts, acc)
   end
@@ -243,7 +243,7 @@ defmodule MPEG.TS.Demuxer do
       # Each stream that contains a PES stream should have its aggregator.
       state.streams
       |> Enum.filter(fn {_pid, stream} ->
-        PMT.get_stream_category(stream.stream_type) in [:audio, :video]
+        PMT.get_stream_category(stream.stream_type) in [:audio, :video, :metadata]
       end)
       |> Enum.reduce(state, fn {pid, _stream}, state ->
         update_in(state, [Access.key!(:stream_aggregators), pid], fn

--- a/lib/mpeg/ts/demuxer.ex
+++ b/lib/mpeg/ts/demuxer.ex
@@ -179,7 +179,7 @@ defmodule MPEG.TS.Demuxer do
   end
 
   defp demux_packets(state, [pkt | pkts], acc)
-       when pkt.pid_class in [:pat, :psi] or is_map_key(state.pids_with_pmt, pkt.pid) do
+       when pkt.pid_class in [:psi, :pat] or is_map_key(state.pids_with_pmt, pkt.pid) do
     with {:ok, psi} <- PSI.unmarshal(pkt.payload, pkt.pusi) do
       state =
         cond do

--- a/lib/mpeg/ts/muxer.ex
+++ b/lib/mpeg/ts/muxer.ex
@@ -187,7 +187,7 @@ defmodule MPEG.TS.Muxer do
     pes_data = Marshaler.marshal(pes)
     header_size = 8
     # PCR should be in nanoseconds, same as PTS/DTS
-    pcr = if send_pcr?, do: (pes.dts || pes.pts)
+    pcr = if send_pcr?, do: pes.dts || pes.pts
 
     {0, @ts_payload_size - header_size}
     |> chunk(byte_size(pes_data))

--- a/lib/mpeg/ts/packet.ex
+++ b/lib/mpeg/ts/packet.ex
@@ -126,9 +126,7 @@ defmodule MPEG.TS.Packet do
   defp parse_scrambling_control(0b11), do: :odd_key
 
   defp parse_pid_class(0x0000), do: :pat
-  # defp parse_pid_class(id) when id in 0x0020..0x1FFA or id in 0x1FFC..0x1FFE, do: :psi
-  defp parse_pid_class(4096), do: :psi
-  defp parse_pid_class(17), do: :psi
+  defp parse_pid_class(id) when id in 0x0020..0x1FFA or id in 0x1FFC..0x1FFE, do: :psi
   defp parse_pid_class(0x1FFF), do: :null_packet
   defp parse_pid_class(_), do: :unsupported
 
@@ -172,7 +170,6 @@ defmodule MPEG.TS.Packet do
   # <<table_id::8, 1::1, 0::1, 3::2, 0::2, section_length::10, table_id_ext::16, 3::2,
   #   version::5, active::1, section::8, last_section::8, rest::bitstring>>,
   defp parse_payload(payload, :payload, :pat), do: {:ok, %{}, payload}
-  defp parse_payload(payload, :payload, :unsupported), do: {:ok, %{}, payload}
   defp parse_payload(_, _, _), do: {:error, :unsupported_packet}
 
   defp parse_adaptation_field(<<>>) do

--- a/test/mpeg/ts/muxer_test.exs
+++ b/test/mpeg/ts/muxer_test.exs
@@ -73,10 +73,10 @@ defmodule MPEG.TS.MuxerTest do
 
   test "mux SCTE35", %{muxer: muxer} do
     {pid, muxer} =
-      Muxer.add_elementary_stream(muxer, :SCTE_35_SPLICE, [
+      Muxer.add_elementary_stream(muxer, :SCTE_35_SPLICE,
         program_info: [%{tag: 5, data: "CUEI"}],
         pid: 500
-      ])
+      )
 
     table = Support.Factory.scte35()
 


### PR DESCRIPTION
This PR:
* creates `StreamAggregator` when PES stream with category `:metadata` is resolved
* performs some formatting 

### Context
We use Demuxer from `kim_mpeg_ts` in [`ex_hls`](https://github.com/membraneframework/ex_hls). 
Recently I updated`mpeg_ts` to version 3.x.x and after adjusting to the new `Demuxer's` API I realized that one of the tests in `ex_hls` is not passing.
It turned out that all the packets from the ID3 timed metadata stream (`METADATA_IN_PES` stream type) were being discarded since they were not recognized as PES because their PID was not in Demuxer's `state.stream_aggregators`.

I also wonder if we need to create stream aggregator for other stream categories, like `:subtitles`, `:cues` etc.

